### PR TITLE
hotfix | Project links

### DIFF
--- a/src/resume/sections/TechnicalProjects/index.tsx
+++ b/src/resume/sections/TechnicalProjects/index.tsx
@@ -67,12 +67,14 @@ const TechnicalProjectItem = ({
                         </ProjectLinkText>
                     </ProjectLink>
                 ))}
+
                 <SubText className="project-dates">
                     <i>
                         ({startDate} - {endDate})
                     </i>
                 </SubText>
-                <SubText>{description}</SubText>
+
+                <SubText dangerouslySetInnerHTML={{ __html: description }} />
             </ProjectDetails>
         </ProjectItemContainer>
     );


### PR DESCRIPTION
# Description

Fixes issue with links displaying as plain text in `TechnicalProjects` section